### PR TITLE
Fixed filebeat connection refused issue

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,6 +85,7 @@ services:
         source: ./filebeat/modules/okta.yml
         target: /usr/share/filebeat/modules.d/okta.yml
         read_only: true
+    restart: always
     networks:
       - elk
     depends_on:


### PR DESCRIPTION
This simply makes it so that if FIlebeat exits, it will restart the container.